### PR TITLE
Make SplashViewController class able to subclass

### DIFF
--- a/VideoSplashKit/Source/VideoSplashViewController.swift
+++ b/VideoSplashKit/Source/VideoSplashViewController.swift
@@ -16,7 +16,7 @@ public enum ScalingMode {
     case resizeAspectFill
 }
 
-public class VideoSplashViewController: UIViewController {
+open class VideoSplashViewController: UIViewController {
     
     private let moviePlayer = AVPlayerViewController()
     private var moviePlayerSoundLevel: Float = 1.0

--- a/VideoSplashKit/Source/VideoSplashViewController.swift
+++ b/VideoSplashKit/Source/VideoSplashViewController.swift
@@ -69,7 +69,7 @@ open class VideoSplashViewController: UIViewController {
         }
     }
     
-    override public func viewDidAppear(_ animated: Bool) {
+    override open func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         moviePlayer.view.frame = videoFrame
         moviePlayer.view.backgroundColor = self.backgroundColor;
@@ -90,7 +90,7 @@ open class VideoSplashViewController: UIViewController {
         }
     }
     
-    public override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+    open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
         
         guard let player = object as? AVPlayer else {
             super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
@@ -108,7 +108,7 @@ open class VideoSplashViewController: UIViewController {
     }
     
     // Override in subclass
-    public func movieReadyToPlay() { }
+    open func movieReadyToPlay() { }
     
     func playerItemDidReachEnd() {
         moviePlayer.player?.seek(to: kCMTimeZero)


### PR DESCRIPTION
Rightnow, because of new introduced visibility operators in swift (open) it is not possible to subclass the ViewController properly.

I just changed the class visibility from public to open, should work now.